### PR TITLE
Add cpu information

### DIFF
--- a/scripts/cpu.sh
+++ b/scripts/cpu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# zenoss-inspector-tags cpu
+
+# Get the results from nproc to show the number of cpus availahle to this process.
+echo "Processors available: `nproc`"
+echo
+
+# Show CPU information.
+lscpu


### PR DESCRIPTION
Adds the output of nproc to show the number of processors available
to the current process.  Also displays processor details via lscpu.