### PR TITLE
Add service logs using serviced log export

### DIFF
--- a/scripts/serviced-log-export.sh
+++ b/scripts/serviced-log-export.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# zenoss-inspector-tags slow big servicelogs
+# zenoss-inspector-deps serviced-service-list.sh
+
+cleanup ()
+{
+    echo "cleaning up"
+    # Remove the temp folder
+    rm -rf $SLE_TEMP
+}
+
+trap cleanup EXIT
+
+
+# Create a temp folder
+SLE_TEMP=serviced-log-export-tmp
+SLE_OUT=serviced-log-export
+mkdir $SLE_TEMP 
+mkdir $SLE_OUT 
+
+# Export logs
+# TODO: Export for top-level services only.  
+#   Otherwise, this includes serviced and other logs that are already pulled by other scripts
+serviced log export --out=$SLE_TEMP/out.tgz
+
+# Extract tgz to the final output dir
+tar -xzf $SLE_TEMP/out.tgz -C $SLE_OUT --strip 1
+
+# cat the index file and modify it to show relative paths to the files
+cat $SLE_OUT/index.txt | sed s/"\([0-9][0-9]*.log\)"/"final\/\1"/
+
+exit $?
+
+


### PR DESCRIPTION
This script loops for each application (tenant) in serviced and does the following:
1.) calls serviced log export for that tenant
2.) extracts the contents of the tgz into a folder serviced-log-export/<tenantID>
3.) dumps the index of the log files to stdout, including relative paths to the log files (see demo)