### PR TITLE
ZEN-22981: opentsdb TTL

### DIFF
--- a/scripts/opentsdb-ttl.py
+++ b/scripts/opentsdb-ttl.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# zenoss-inspector-info
+# zenoss-inspector-tags rm opentsdb ZEN-22981
+
+import subprocess as sp
+
+
+def run(cmd):
+    p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        raise sp.CalledProcessError(p.returncode, ' '.join(cmd))
+    return stdout, stderr
+
+
+def main():
+    cmd = ["serviced", "service", "shell", "writer",
+           "bash", "-c", "echo list|/opt/hbase/bin/hbase shell"]
+    stdout, stderr = run(cmd)
+
+    # Get the tsdb table names for all tenants
+    for line in stdout.strip().split("\n"):
+        if line.endswith("-tsdb"):
+            cmd = ["serviced", "service", "shell", "writer",
+                   "bash", "-c",
+                   "echo 'describe \"{}\"'|/opt/hbase/bin/hbase shell".format(
+                       line)]
+            stdout, stderr = run(cmd)
+            if ("TTL => 'FOREVER'" in stdout or
+                    "TTL => '2147483647'" in stdout):
+                print "Tenant {} has opentsdb TTL set to FOREVER".format(
+                    line)
+                print "Set to 90 days with:"
+                print "    serviced service shell writer " \
+                    "/opt/opentsdb/set-opentsdb-table-ttl.sh 7776000"
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opentsdb-ttl.py
+++ b/scripts/opentsdb-ttl.py
@@ -21,16 +21,20 @@ def main():
 
     # Get the tsdb table names for all tenants
     for line in stdout.strip().split("\n"):
+        # Only check tsdb tables
         if line.endswith("-tsdb"):
+            # Describe the table
             cmd = ["serviced", "service", "shell", "writer",
                    "bash", "-c",
                    "echo 'describe \"{}\"'|/opt/hbase/bin/hbase shell".format(
                        line)]
             stdout, stderr = run(cmd)
+
+            # Check the TTL
             if ("TTL => 'FOREVER'" in stdout or
                     "TTL => '2147483647'" in stdout):
-                print "Tenant {} has opentsdb TTL set to FOREVER".format(
-                    line)
+                print "CHECK FAILED: Tenant {} has opentsdb TTL set " \
+                    "to FOREVER".format(line)
                 print "Set to 90 days with:"
                 print "    serviced service shell writer " \
                     "/opt/opentsdb/set-opentsdb-table-ttl.sh 7776000"


### PR DESCRIPTION
I added this script to check for the `TTL` setting for the RM opentsdb database (from [ZEN-22981](https://jira.zenoss.com/browse/ZEN-22981)). If it is set to `FOREVER` or `2147483647`, then a message is shown along with instructions to set the TTL to 90 days.

The script first gets a list of databases in `hbase` to find any of the form `<tenant-id>-tsdb`. This is to accommodate multiple instances running on a single controlcenter instance.

The message shown if the `TTL` is `FOREVER` includes the text `CHECK FAILED`, which will be used by services/support to ask a customer to run the inspect script and then to grep for this in the output to determine if a setting needs to be changed for our best practices.