### PR TITLE
Capture and log the version of inspector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+inspect ident export-subst
 inspector.version ident export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inspector.version ident export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 inspect ident export-subst
-inspector.version ident export-subst

--- a/inspect
+++ b/inspect
@@ -13,6 +13,14 @@ from subprocess import check_call
 from termcolor import colored
 from script import Script
 
+#
+# For now, we are using the git SHA as the version number for inspector, with the plan
+# that eventually this evolve to a regular n.n.n version number once we have inspector
+# on a formal release train.
+#
+# Note that the Format variable will be replaced with the git SHA whenever a ZIP is created
+# with the git-archive command.
+#
 VERSION = "$Format:%H$"
 PATH = os.path.dirname(os.path.abspath(__file__))
 SCRIPTS = os.environ.get("ZI_SCRIPTS") or os.path.join(PATH, "scripts")
@@ -70,6 +78,8 @@ def main():
     padding = max([len(s.basename) for s in scripts]) + 4
 
     os.mkdir(RESULTS)
+
+    log("Starting inspector version %s" % VERSION, "blue", attrs=["bold"])
 
     to_run = scripts
     have_run = []

--- a/inspect
+++ b/inspect
@@ -13,6 +13,7 @@ from subprocess import check_call
 from termcolor import colored
 from script import Script
 
+VERSION = "$Format:%H$"
 PATH = os.path.dirname(os.path.abspath(__file__))
 SCRIPTS = os.environ.get("ZI_SCRIPTS") or os.path.join(PATH, "scripts")
 RESULTS = os.environ.get("ZI_RESULTS") or "inspected-%s" % datetime.today().isoformat().replace(":", "-")
@@ -40,6 +41,7 @@ def get_scripts():
 
 def get_args():
     parser = argparse.ArgumentParser(description="Inspect a Zenoss installation.")
+    parser.add_argument("-v", "--version", action="store_true", default=False, help="Print version and exit.")
     parser.add_argument("--no-remove", action="store_true", default=False,
                         help="Don't remove working directory.")
     parser.add_argument("--no-save", action="store_true", default=False,
@@ -55,6 +57,10 @@ def get_args():
 def main():
     args = get_args()
     scripts = get_scripts()
+
+    if args.version:
+        print VERSION
+        return
 
     if args.whitelist:
         scripts = [s for s in scripts if any(t in args.whitelist for t in s.tags)]

--- a/inspect
+++ b/inspect
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+#
+# Commit: $Format:%H$
+# Date:   $Format:%cD$
 
 import os
 import sys

--- a/inspector.version
+++ b/inspector.version
@@ -1,0 +1,3 @@
+Commit: $Format:%H$
+Author: $Format:%cn$ $Format:%ce$
+Date:   $Format:%cD$

--- a/inspector.version
+++ b/inspector.version
@@ -1,3 +1,0 @@
-Commit: $Format:%H$
-Author: $Format:%cn$ $Format:%ce$
-Date:   $Format:%cD$


### PR DESCRIPTION
Fixes INSP-23

For now, we are simply using the git SHA as the version number.  This really only works with copies of inspector which are generated by `git archive` - hopefully, the download ZIP feature of github will use that command :-)

To see the current version, `inspect --version`.  
Also, note that the ` inspector.log` file in each run of inspector will begin with a line like:
```
Starting inspector version 45643007dce1297afdc3cf1cd642dce26c32da08
```