### PR TITLE
Adding checks to ensure we are on version 7.2 and that we are looking…

### DIFF
--- a/scripts/kernel-version-check.py
+++ b/scripts/kernel-version-check.py
@@ -11,9 +11,8 @@ def main():
         with open("uname-a.sh.stdout", 'r') as f:
             line = f.read()
             kver = tuple(map(int, re.search(r'^[^ ]+ [^ ]+ (\d+)\.(\d+)\.(\d+)-(\d+)', line).groups())) 
-            if kver < (3,10,0,327):
-                if kver > (3,10,0,229):
-                    print 'Kernel version does not support fstrim, update to version 3.10.0-327 or higher'
+            if (3,10,0,229) < kver < (3,10,0,327):        
+                print 'Kernel versions between 3.10.0-229 and 3.10.0-327 do not support fstrim which is used to free unused storage blocks over time. Update to version 3.10.0-327 or higher to avoid running out of usable storage'
 
 if __name__ == "__main__":
     main()

--- a/scripts/kernel-version-check.py
+++ b/scripts/kernel-version-check.py
@@ -3,12 +3,17 @@
 # zenoss-inspector-info
 # zenoss-inspector-deps uname-a.sh
 import re
+import platform
 
 def main():
-    with open("uname-a.sh.stdout", 'r') as f:
-        line = f.read()
-        if tuple(map(int, re.search(r'^[^ ]+ [^ ]+ (\d+)\.(\d+)\.(\d+)-(\d+)', line).groups())) < (3,10,0,327):
-            print 'Kernel version must be 3.10.0-327 or higher, please update your kernel'
+    # Check for Centos/RHEL 7.2
+    if tuple(map(int, platform.linux_distribution()[1].split('.'))) >= (7,2):
+        with open("uname-a.sh.stdout", 'r') as f:
+            line = f.read()
+            kver = tuple(map(int, re.search(r'^[^ ]+ [^ ]+ (\d+)\.(\d+)\.(\d+)-(\d+)', line).groups())) 
+            if kver < (3,10,0,327):
+                if kver > (3,10,0,229):
+                    print 'Kernel version does not support fstrim, update to version 3.10.0-327 or higher'
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes for INSP-14 to only look at 7.2 version Cent/RHEL and at kernels between 3.10.0.229 and 3.10.0-327