### PR TITLE
Update tags to get agent-specific data

### DIFF
--- a/inspect-serviced-worker.sh
+++ b/inspect-serviced-worker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./inspect --whitelist docker network os serviced-worker $*

--- a/scripts/cpu.sh
+++ b/scripts/cpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags cpu
+# zenoss-inspector-tags cpu os
 
 # Get the results from nproc to show the number of cpus availahle to this process.
 echo "Processors available: `nproc`"

--- a/scripts/df.sh
+++ b/scripts/df.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 df -PTha --total

--- a/scripts/dfinode.sh
+++ b/scripts/dfinode.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 df -PThai --total

--- a/scripts/diskspace.py
+++ b/scripts/diskspace.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
+# zenoss-inspector-tags os
 # zenoss-inspector-deps df.sh
 
 CUTOFF = 90

--- a/scripts/docker-stats.sh
+++ b/scripts/docker-stats.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# zenoss-inspector-tags docker
+
 docker ps -q | xargs docker stats --no-stream
 

--- a/scripts/etc-default-serviced.sh
+++ b/scripts/etc-default-serviced.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags serviced serviced-worker
+
 cat /etc/default/serviced

--- a/scripts/etc-redhat-release.sh
+++ b/scripts/etc-redhat-release.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 cat /etc/redhat-release

--- a/scripts/etc-systemd-journald-conf.sh
+++ b/scripts/etc-systemd-journald-conf.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-cat /etc/systemd/journald.conf 
+# zenoss-inspector-tags os
+
+cat /etc/systemd/journald.conf

--- a/scripts/free.sh
+++ b/scripts/free.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 free  -h -l -t

--- a/scripts/hostname.sh
+++ b/scripts/hostname.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# zenoss-inspector-tags network os
+
 echo "hostname: `hostname`"
 echo "hostname IP: `hostname -i`"
 echo "hostid: `hostid`"

--- a/scripts/inodes.py
+++ b/scripts/inodes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
+# zenoss-inspector-tags os
 # zenoss-inspector-deps dfinode.sh
 
 CUTOFF = 90

--- a/scripts/journalctl-disk-usage.sh
+++ b/scripts/journalctl-disk-usage.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 journalctl --disk-usage
 

--- a/scripts/journalctl-serviced.sh
+++ b/scripts/journalctl-serviced.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced
+# zenoss-inspector-tags serviced serviced-worker
 
 journalctl -u serviced
 

--- a/scripts/kernel-version-check.py
+++ b/scripts/kernel-version-check.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
+# zenoss-inspector-tags os
 # zenoss-inspector-deps uname-a.sh
+
 import re
 
 def main():

--- a/scripts/linux-distro-check.py
+++ b/scripts/linux-distro-check.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
+# zenoss-inspector-tags os
 
 import platform
 

--- a/scripts/localhost-loopback.py
+++ b/scripts/localhost-loopback.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
+# zenoss-inspector-tags network
 # zenoss-inspector-deps etchosts.sh
 
 def main():

--- a/scripts/lsb-release-a.sh
+++ b/scripts/lsb-release-a.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 lsb_release -a
 

--- a/scripts/lsb-release-a.sh
+++ b/scripts/lsb-release-a.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# zenoss-inspector-info
 # zenoss-inspector-tags os
 
 command -v lsb_release >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-   echo "lsb_release is not installed; distribution details not available."
-   exit 0;
+   echo "lsb_release is not installed." 1>&2
+   exit 1;
 fi
 
 lsb_release -a

--- a/scripts/lsb-release-a.sh
+++ b/scripts/lsb-release-a.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+# zenoss-inspector-info
 # zenoss-inspector-tags os
 
-lsb_release -a
+command -v lsb_release >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+   echo "lsb_release is not installed; distribution details not available."
+   exit 0;
+fi
 
+lsb_release -a

--- a/scripts/lsof.sh
+++ b/scripts/lsof.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags slow
+# zenoss-inspector-tags slow os
 
 lsof

--- a/scripts/lsof.sh
+++ b/scripts/lsof.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# zenoss-inspector-info
 # zenoss-inspector-tags slow os
+
+command -v lsof >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+   echo "lsof is not installed."
+   exit 0;
+fi
 
 lsof

--- a/scripts/lsof.sh
+++ b/scripts/lsof.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# zenoss-inspector-info
 # zenoss-inspector-tags slow os
 
 command -v lsof >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-   echo "lsof is not installed."
-   exit 0;
+   echo "lsof is not installed." 1>&2
+   exit 1;
 fi
 
 lsof

--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 mount
 

--- a/scripts/netstat-plant.sh
+++ b/scripts/netstat-plant.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 netstat -plant

--- a/scripts/ps-aux.sh
+++ b/scripts/ps-aux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags process
+# zenoss-inspector-tags process docker
 
 ps aux

--- a/scripts/ps-aux.sh
+++ b/scripts/ps-aux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags process docker
+# zenoss-inspector-tags process docker os
 
 ps aux

--- a/scripts/selinux-config.sh
+++ b/scripts/selinux-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags selinux
+# zenoss-inspector-tags selinux os
 
 cat /etc/selinux/config

--- a/scripts/selinux-status.sh
+++ b/scripts/selinux-status.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags selinux
+# zenoss-inspector-tags selinux os
 # zenoss-inspector-deps selinux-config.sh
 
 SELINUX_CONFIG=`grep "^SELINUX=" selinux-config.sh.stdout 2>/dev/null`

--- a/scripts/service-status.py
+++ b/scripts/service-status.py
@@ -2,7 +2,7 @@
 
 # zenoss-inspector-info
 # zenoss-inspector-deps systemctl-status.sh
-# zenoss-inspector-tags docker serviced
+# zenoss-inspector-tags docker serviced serviced-worker
 
 
 class SystemService(object):

--- a/scripts/serviced-config.sh
+++ b/scripts/serviced-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced
+# zenoss-inspector-tags serviced serviced-worker
 
 serviced config

--- a/scripts/serviced-service-status.sh
+++ b/scripts/serviced-service-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker
+# zenoss-inspector-tags serviced
 
 serviced service status
 

--- a/scripts/serviced-service-status.sh
+++ b/scripts/serviced-service-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced
+# zenoss-inspector-tags serviced serviced-worker
 
 serviced service status
 

--- a/scripts/serviced-version.sh
+++ b/scripts/serviced-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced
+# zenoss-inspector-tags serviced serviced-worker
 
 serviced version
 

--- a/scripts/systemctl-status.sh
+++ b/scripts/systemctl-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker serviced
+# zenoss-inspector-tags docker serviced serviced-worker
 
 systemctl show --property=Names,Description,LoadState,ActiveState,UnitFileState dnsmasq
 systemctl show --property=Names,Description,LoadState,ActiveState,UnitFileState docker

--- a/scripts/top.sh
+++ b/scripts/top.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 top -b -n1
 

--- a/scripts/uname-a.sh
+++ b/scripts/uname-a.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+# zenoss-inspector-tags os
+
 uname -a

--- a/scripts/var-log-journal-exists.sh
+++ b/scripts/var-log-journal-exists.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
+# zenoss-inspector-tags os
 
 if [ ! -d "/var/log/journal" ]; then
   echo "/var/log/journal does not exist. Persistent storage for log files not enabled."


### PR DESCRIPTION
Fixes INSP-24

Rather than adding a `serviced-worker` tag to all of the OS, network, and docker scripts, I choose instead to create a wrapper script, `inspect-serviced-worker.sh`, which invokes inspector with a whitelist of tags.