### PR TITLE
Adding checks for permissions and ownership of hbase-zookeeper data d…

### DIFF
--- a/scripts/serviced-storage.py
+++ b/scripts/serviced-storage.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-deps serviced-config.sh
+# zenoss-inspector-deps serviced-config.sh serviced-storage.sh
+import os
+from stat import *
 
 def main():
     with open("serviced-config.sh.stdout", 'r') as f:
@@ -27,6 +29,18 @@ def main():
         print ("serviced is configured to use a filesystem of type '%s', but 'devicemapper' is recommended." % fs_type)
     elif isMaster and not thinpool_device:
         print ("serviced is configured to use devicemapper, but SERVICED_DM_THINPOOLDEV is not defined")
+
+    with open("serviced-storage.sh.stdout", 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            if "Application Data" in line:
+                subVolumePath = "/opt/serviced/var/volumes/" + line.split()[0]
+                for d in range(1,4):
+                    path = subVolumePath + "/hbase-zookeeper-" + str(d)
+                    if oct(os.stat(path)[ST_MODE])[-3:] != "755" or os.stat(path)[ST_UID] != 102 or os.stat(path)[ST_GID] != 105:
+                        print 'Permision or ownership is incorrect on: %s' % subVolumePath + "/hbase-zookeeper-" + str(d)
+                        print 'hbase-zookeeper-* directory permissions and ownership should be: "drwxr-xr-x 2  102  105"'
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/serviced-storage.sh
+++ b/scripts/serviced-storage.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# zenoss-inspector-tags serviced serviced-worker
+
+serviced-storage status -o=dm.thinpooldev=serviced-serviced--pool /opt/serviced/var/volumes


### PR DESCRIPTION
Added checks for file perms and ownership of the hbase-zookeeper directories on the DFS, this required an additional shell script serviced-storage.sh to get volume information into a stdout file that I could pull the subvolume id from. 