### PR TITLE
Adding "verify" tag to the following scripts

### DIFF
--- a/scripts/check-bip-dns.py
+++ b/scripts/check-bip-dns.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 # zenoss-inspector-deps docker-config.sh
 
 import subprocess as sp

--- a/scripts/check-docker-service.py
+++ b/scripts/check-docker-service.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 # zenoss-inspector-deps docker-service.sh
 
 import ConfigParser

--- a/scripts/df.sh
+++ b/scripts/df.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags os
+# zenoss-inspector-tags os verify
 
 df -PTha --total

--- a/scripts/diskspace.py
+++ b/scripts/diskspace.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags os
+# zenoss-inspector-tags os verify
 # zenoss-inspector-deps df.sh
 
 CUTOFF = 90

--- a/scripts/docker-config.sh
+++ b/scripts/docker-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 
 cat /etc/sysconfig/docker

--- a/scripts/docker-info.sh
+++ b/scripts/docker-info.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 
 docker info

--- a/scripts/docker-service.sh
+++ b/scripts/docker-service.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 
 cat /etc/systemd/system/docker.service.d/docker.conf || cat /usr/lib/systemd/system/docker.service

--- a/scripts/docker-storage.sh
+++ b/scripts/docker-storage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags docker
+# zenoss-inspector-tags docker verify
 # zenoss-inspector-deps docker-info.sh
 
 # First make sure docker is using devicemapper

--- a/scripts/etchosts.sh
+++ b/scripts/etchosts.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags network
+# zenoss-inspector-tags network verify
 
 cat /etc/hosts

--- a/scripts/localhost-loopback.py
+++ b/scripts/localhost-loopback.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags network
+# zenoss-inspector-tags network verify
 # zenoss-inspector-deps etchosts.sh
 
 def main():

--- a/scripts/opentsdb-ttl.py
+++ b/scripts/opentsdb-ttl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags rm opentsdb ZEN-22981
+# zenoss-inspector-tags rm opentsdb verify ZEN-22981
 
 import subprocess as sp
 

--- a/scripts/service-status.py
+++ b/scripts/service-status.py
@@ -2,7 +2,7 @@
 
 # zenoss-inspector-info
 # zenoss-inspector-deps systemctl-status.sh
-# zenoss-inspector-tags docker serviced serviced-worker
+# zenoss-inspector-tags docker serviced serviced-worker verify
 
 
 class SystemService(object):

--- a/scripts/serviced-config-agent.sh
+++ b/scripts/serviced-config-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags serviced config
+# zenoss-inspector-tags serviced config verify
 # zenoss-inspector-deps serviced-config.sh
 
 # Verify that if this is a master node, that it is also an agent

--- a/scripts/serviced-config.sh
+++ b/scripts/serviced-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker
+# zenoss-inspector-tags serviced serviced-worker verify
 
 serviced config

--- a/scripts/serviced-storage.py
+++ b/scripts/serviced-storage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# zenoss-inspector-info
+# zenoss-inspector-info verify
 # zenoss-inspector-deps serviced-config.sh serviced-storage.sh
 import os
 from stat import *

--- a/scripts/serviced-storage.sh
+++ b/scripts/serviced-storage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker
+# zenoss-inspector-tags serviced serviced-worker verify
 
 serviced-storage status -o=dm.thinpooldev=serviced-serviced--pool /opt/serviced/var/volumes

--- a/scripts/systemctl-status.sh
+++ b/scripts/systemctl-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker serviced serviced-worker
+# zenoss-inspector-tags docker serviced serviced-worker verify
 
 systemctl show --property=Names,Description,LoadState,ActiveState,UnitFileState dnsmasq
 systemctl show --property=Names,Description,LoadState,ActiveState,UnitFileState docker

--- a/scripts/var-log-journal-exists.sh
+++ b/scripts/var-log-journal-exists.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags os
+# zenoss-inspector-tags os verify
 
 if [ ! -d "/var/log/journal" ]; then
   echo "/var/log/journal does not exist. Persistent storage for log files not enabled."


### PR DESCRIPTION
Adding "verify" tag to scripts, here is it being run with the change:

[root@bill5cc inspector-master]# ./inspect -w verify
docker-config.sh             done
var-log-journal-exists.sh    done
etchosts.sh                  done
df.sh                        done
docker-service.sh            done
localhost-loopback.py        done
systemctl-status.sh          done
diskspace.py                 done
check-bip-dns.py             done
check-docker-service.py      done
service-status.py            done
docker-info.sh               done
docker-storage.sh            done
serviced-config.sh           done
serviced-config-agent.sh     done
Waiting 293 seconds for opentsdb-ttl.py serviced-storage.sh...
serviced-storage.sh          done
Waiting 285 seconds for opentsdb-ttl.py...
Waiting 280 seconds for opentsdb-ttl.py...
Waiting 275 seconds for opentsdb-ttl.py...
Waiting 270 seconds for opentsdb-ttl.py...
Waiting 265 seconds for opentsdb-ttl.py...
Waiting 260 seconds for opentsdb-ttl.py...
Waiting 255 seconds for opentsdb-ttl.py...
Waiting 250 seconds for opentsdb-ttl.py...
Waiting 245 seconds for opentsdb-ttl.py...
Waiting 240 seconds for opentsdb-ttl.py...
Waiting 235 seconds for opentsdb-ttl.py...
Waiting 230 seconds for opentsdb-ttl.py...
Waiting 225 seconds for opentsdb-ttl.py...
Waiting 219 seconds for opentsdb-ttl.py...
Waiting 214 seconds for opentsdb-ttl.py...
opentsdb-ttl.py              done
Limiting result logs to 100000 lines.
Compressing results: inspected-2016-07-07T14-27-12.507954.tar.gz
Cleaning up...
Done.
