### PR TITLE
Verify docker service configuration

### DIFF
--- a/scripts/check-docker-config.sh
+++ b/scripts/check-docker-config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# zenoss-inspector-info
+# zenoss-inspector-tags docker config verify
+# zenoss-inspector-deps docker-config.sh
+
+grep -E -i '--exec-opt native.cgroupdriver=cgroupfs' docker-config.sh.stdout &>/dev/null
+
+if [ $? -ne 0 ]
+    then
+        echo "Incorrect docker config: Add '--exec-opt native.cgroupdriver=cgroupfs' to /etc/sysconfig/docker"
+fi

--- a/scripts/check-docker-config.sh
+++ b/scripts/check-docker-config.sh
@@ -4,7 +4,7 @@
 # zenoss-inspector-tags docker config verify
 # zenoss-inspector-deps docker-config.sh
 
-grep -E -i '--exec-opt native.cgroupdriver=cgroupfs' docker-config.sh.stdout &>/dev/null
+grep -i -- '--exec-opt native.cgroupdriver=cgroupfs' docker-config.sh.stdout &>/dev/null
 
 if [ $? -ne 0 ]
     then


### PR DESCRIPTION
This commit adds check-docker-config.sh, which ensures the cgroup is set in /etc/sysconfig/docker. It does not check for the other options (devicemapper and dns/bip) as those are checked in other scripts (docker-storage.sh and check-bip-dns.py, respectively).

The commit also modifies the check-docker-service.py script:

* Don't bail on one failure, if there are multiple failures in the service file, they are all shown
* Now checks for correct ExecStart and TasksMax

Implements INSP-2