### PR TITLE
Feature/insp 31

### DIFF
--- a/scripts/service-startup-check.py
+++ b/scripts/service-startup-check.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags os verify
+# zenoss-inspector-tags verify
 # zenoss-inspector-deps serviced-service-list-v.sh
+import json
+from pprint import pprint
 
 def main():
-    with open("serviced-service-list-v.sh.stdout", 'r') as f:
-        lines = f.readlines()
-    for line in lines:
-        if "Startup" and "/opt/zenoss/ZenPacks" in line:
-            print 'There is a problem with the Startup line for the following:'
-            print line
-            print 'To correct this edit the service definition with "serviced service edit SERVICE_NAME"'
-            print 'and edit the Startup line to use the symbolic link at "/opt/zenoss/bin"'
+    with open('serviced-service-list-v.sh.stdout') as data_file:
+        data = json.load(data_file)
+        #pprint(data)
+        for i in data:
+            if "/opt/zenoss/ZenPacks" in i["Startup"]:
+                print "There is an issue with Startup command %s" % i["Name"]
+                print i["Startup"]
+                print 'To correct this you should edit the service definition',\
+                      'with "serviced service edit %s" changing the Startup' % i["Name"], \
+                      'line to use the symbolic link at "/opt/zenoss/bin/%s"' % i["Name"]
+
 if __name__ == "__main__":
     main()

--- a/scripts/service-startup-check.py
+++ b/scripts/service-startup-check.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+# zenoss-inspector-info
+# zenoss-inspector-tags os verify
+# zenoss-inspector-deps serviced-service-list-v.sh
+
+def main():
+    with open("serviced-service-list-v.sh.stdout", 'r') as f:
+        lines = f.readlines()
+    for line in lines:
+        if "Startup" and "/opt/zenoss/ZenPacks" in line:
+            print 'There is a problem with the Startup line for the following:'
+            print line
+            print 'To correct this edit the service definition with "serviced service edit SERVICE_NAME"'
+            print 'and edit the Startup line to use the symbolic link at "/opt/zenoss/bin"'
+if __name__ == "__main__":
+    main()

--- a/scripts/service-startup-check.py
+++ b/scripts/service-startup-check.py
@@ -12,7 +12,7 @@ def main():
         #pprint(data)
         for i in data:
             if "/opt/zenoss/ZenPacks" in i["Startup"]:
-                print "There is an issue with Startup command %s" % i["Name"]
+                print "There is an issue with the Startup command for %s" % i["Name"]
                 print i["Startup"]
                 print 'To correct this you should edit the service definition',\
                       'with "serviced service edit %s" changing the Startup' % i["Name"], \

--- a/scripts/serviced-service-list-v.sh
+++ b/scripts/serviced-service-list-v.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced
+# zenoss-inspector-tags serviced verify
 
 serviced service list -v
 


### PR DESCRIPTION
Added check for misconfigured start up commands in service definitions. In early versions of CC it was possible for a ZenPack to install a service Startup that had the path to the binary in the ZenPack directory rather than a sim link from /opt/zenoss/bin this can break a daemon on updates to a zenpack. This is a rudimentary check for improper paths in Startup.

Examples

This is a valid Startup:
"Startup": "su - zenoss -c \"/opt/zenoss/bin/zenvsphere run -c --logfileonly --workers {{.Instances}} --workerid $CONTROLPLANE_INSTANCE_ID --monitor {{(parent .).Name}} \"",

This is invalid:
"Startup": "su - zenoss -c \" /opt/zenoss/ZenPacks/ZenPacks.zenoss.vSphere-3.4.0-py2.7.egg/ run -c --logfileonly --workers {{.Instances}} --workerid $CONTROLPLANE_INSTANCE_ID --monitor {{(parent .).Name}} \"",
