### PR TITLE
Don't do anything for serviced-config-agent.sh unless CC version < 1.2

### DIFF
--- a/scripts/serviced-config-agent.sh
+++ b/scripts/serviced-config-agent.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags serviced config verify
-# zenoss-inspector-deps serviced-config.sh
+# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-deps serviced-config.sh serviced-version.sh
 
 # Verify that if this is a master node, that it is also an agent
 
 grep -E -i 'SERVICED_MASTER=(1|true|t|yes)' serviced-config.sh.stdout &>/dev/null
+if [ $? -ne 0 ]
+then
+    exit
+fi
 
-if [ $? -eq 0 ]
-    then
+CC_VERSION=`grep -w 'Version:' serviced-version.sh.stdout 2>/dev/null | awk '{print $2}' | cut -d\. -f1-2`
+if [[ "$CC_VERSION" == "1.0" || "$CC_VERSION" == "1.1" ]]
+then
         grep -E -i "SERVICED_AGENT=(1|true|t|yes)" serviced-config.sh.stdout &>/dev/null
         if [ $? -ne 0 ]
-            then echo "CHECK FAILED: SERVICED_AGENT must be enabled on the Master for serviced commands to work"
+        then
+            echo "CHECK FAILED: SERVICED_AGENT must be enabled on the Master for serviced commands to work"
         fi
 fi

--- a/scripts/serviced-version.sh
+++ b/scripts/serviced-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker
+# zenoss-inspector-tags config serviced serviced-worker verify
 
 serviced version
 


### PR DESCRIPTION
Fixes INSP-67

The SERVICED_AGENT variable was removed in CC 1.2 so need to check for it, but keep the check for CC versions 1.0.x and 1.1.x