### PR TITLE
Feature/insp 85

### DIFF
--- a/scripts/check-serviced-thinpool.py
+++ b/scripts/check-serviced-thinpool.py
@@ -41,10 +41,17 @@ def check_thinpool():
     err = ""
     if stats['data_free'] < stats['data_min_free']:
         err += "\nThe thinpool storage free (%s) is under the minimum threshold (%s)" % \
-            (sizefmt.humansize(stats['data_free']), sizefmt.humansize(stats['data_min_free']))
+            (sizefmt.bytesize(stats['data_free']), sizefmt.bytesize(stats['data_min_free']))
     if stats['meta_free'] < stats['meta_min_free']:
         err += "\nThe thinpool metadata free (%s) is under the minimum threshold (%s)" % \
-            (sizefmt.humansize(stats['meta_free']), sizefmt.humansize(stats['meta_min_free']))
+            (sizefmt.bytesize(stats['meta_free']), sizefmt.bytesize(stats['meta_min_free']))
+    if len(stats['tenants']):
+        for tenant in stats['tenants']:
+            if tenant['free'] < stats['data_min_free']:
+                err += "\nThe tenant volume %s available space (%s) is under the minimum threshold (%s)" % \
+                    (tenant['id'], sizefmt.bytesize(tenant['free']), sizefmt.bytesize(stats['data_min_free']))
+    else:
+        err += "\nNo tenant devices are mounted. Unable to verify tenant free space."
     return err
 
 

--- a/scripts/check-serviced-thinpool.py
+++ b/scripts/check-serviced-thinpool.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 ##############################################################################
 #
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+#
 # Checks the serviced thinpool data and metadata to see if an upgrade would put the
 # system into Emergency Shutdown mode.
 #
@@ -11,207 +18,33 @@
 
 # zenoss-inspector-info
 # zenoss-inspector-tags verify
-# zenoss-inspector-deps serviced-config.sh
+# zenoss-inspector-deps thinpool_data.py
 
-import re
-import subprocess
-import sys
+import ast
+import lib.sizefmt as sizefmt
 
-##############################################################################
-# size format helper functions
-
-KB  = 1000
-MB  = 1000 * KB
-GB  = 1000 * MB
-TB  = 1000 * GB
-PB  = 1000 * TB
-
-KiB = 1024
-MiB = 1024 * KiB
-GiB = 1024 * MiB
-TiB = 1024 * GiB
-PiB = 1024 * TiB
-
-SIZES = {
-    'b': 1, 'kb': KiB, 'mb': MiB, 'gb': GiB, 'tb': TiB, 'pb': PiB,
-    'B': 1, 'Kb': KB, 'Mb': MB, 'Gb': GB, 'Tb': TB, 'Pb': PB,
-}
-decimapAbbrs = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-binaryAbbrs = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
-sizeRegex = re.compile("^([-]?)(\d+(.\d+)?) ?([KkMmGgTtPp])?(i)?([Bb])?$")
-
-def parse_size(size):
-    """
-    Parses the human-readable size string into the amount it represents
-    as a float value. Upper case units are base 1000, lowercase base 1024.
-    If the unit has "i" in the middle it uses base 1024.
-
-    >>> parse_size("10K")
-    10000.0
-    >>> parse_size("-10K")
-    -10000.0
-    >>> parse_size("10 KB")
-    10000.0
-    >>> parse_size("10 G")
-    10000000000.0
-    >>> parse_size("10GB")
-    10000000000.0
-    >>> parse_size("10k")
-    10240.0
-    >>> parse_size("-10k")
-    -10240.0
-    >>> parse_size("10 kb")
-    10240.0
-    >>> parse_size("10gb")
-    10737418240.0
-    >>> parse_size("10g")
-    10737418240.0
-    >>> parse_size("10GiB")
-    10737418240.0
-    """
-    match = sizeRegex.match(size)
-    if not match:
-        return None
-    neg = -1 if match.group(1) else 1
-    m1 = float(match.group(2))
-    m2 = match.group(4) if match.group(4) else ''
-    if match.group(5): m2 = m2.lower()
-    m3 = match.group(6).lower() if match.group(6) else 'b'
-    return neg * m1 * SIZES[(m2 + m3)]
-
-
-def customsize(size, base, map):
-    neg = 1 if size >= 0 else -1
-    size = size * neg
-    i = 0
-    while size >= base and i < len(map)-1:
-        size = size / base
-        i = i + 1
-    size = str(round(size, 3) * neg).strip('0').strip('.') or "0"
-    return '%s %s' % (size, map[i])
-
-
-def humansize(size):
-    """
-    Converts the size string given into a human readable format
-    using 1000 as the base.
-
-    >>> humansize(0)
-    '0 B'
-    >>> humansize(-0)
-    '0 B'
-    >>> humansize(1234)
-    '1.234 KB'
-    >>> humansize(123456)
-    '123.456 KB'
-    >>> humansize(1234567890)
-    '1.235 GB'
-    >>> humansize(-1234567890)
-    '-1.235 GB'
-    """
-    if not isinstance(size, (int, float)):
-        raise ValueError('humansize() only takes int or float arguments')
-    return customsize(size, 1000.0, decimapAbbrs)
-
-
-def bytesize(size):
-    """
-    Converts the size string given into a human readable format
-    using 1024 as the base.
-
-    >>> bytesize(0)
-    '0 B'
-    >>> bytesize(-0)
-    '0 B'
-    >>> bytesize(1234)
-    '1.205 KiB'
-    >>> bytesize(123456)
-    '120.563 KiB'
-    >>> bytesize(1234567890)
-    '1.15 GiB'
-    >>> bytesize(-1234567890)
-    '-1.15 GiB'
-    >>> bytesize(1024*1024*1024)
-    '1 GiB'
-    """
-    if not isinstance(size, (int, float)):
-        raise ValueError('bytesize() only takes int or float arguments')
-    return customsize(size, 1024.0, binaryAbbrs)
-
-
-##############################################################################
-# Gather serviced and thinpool data from the that we want. 
-
-# Returns the min data and metadata storage sizes.
-def get_serviced_settings(config):
-    data = {}
-    s_storage_min_free = config.get("SERVICED_STORAGE_MIN_FREE", "3G")
-    storage_min_free = parse_size(s_storage_min_free) or (3 * GB) # Default setting if we can't parse.
-    data['SERVICED_STORAGE_MIN_FREE'] = s_storage_min_free
-    data['data_min_free'] = storage_min_free
-    data['meta_min_free'] = int(storage_min_free * 0.02)
-    return data
-
-
-# Returns a mapping representing data for the serviced thinpool.
-def get_tpool_stats(config):
-    data = {}
-    thinpooldev = config.get("SERVICED_DM_THINPOOLDEV", "serviced")
-    cmd = "lvs -o lv_size,data_percent,lv_metadata_size,metadata_percent %s 2>/dev/null | grep -vi lsize" % thinpooldev
-    stats = subprocess.check_output(cmd, shell=True).strip()
-    if not stats:
-        return data
-    stats = filter(None, stats.split(' '))
-    data['thinpooldev'] = thinpooldev
-    data['data_size'] = parse_size(stats[0])
-    data['data_percent'] = parse_size(stats[1])
-    data['data_free'] = data['data_size'] * data['data_percent']
-    data['meta_size'] = parse_size(stats[2])
-    data['meta_percent'] = parse_size(stats[3])
-    data['meta_free'] = data['meta_size'] * data['meta_percent']
-    return data
-
-
-# Parse the serviced-config output into a dict for later use.
-def parse_serviced_config():
-    with open('serviced-config.sh.stdout', 'r') as f:
-        lines = f.readlines()
-
-    data = {}
-    for line in lines:
-        line = line.strip()
-        if line.startswith('#'):
-            continue
-
-        split = line.split("=")
-        data[split[0].strip()] = split[1].strip()
-    return data
-
-
-# Returns a map of data for the serviced thin pool.
 def get_thinpool_data():
-    config = parse_serviced_config()
-    data = get_serviced_settings(config)
-    data.update(get_tpool_stats(config))
-    return data
+    '''
+    Parses the output of the thinpool_data.py script into a dictionary.
+    '''
+    with open('thinpool_data.py.stdout', 'r') as f:
+        lines = f.read()
+    return ast.literal_eval(lines)
 
 
-##############################################################################
-# After we gather the data, check that we have enough required space to keep
-# us out of emergency shutdown mode on upgrade.
-
-
-# Returns "" if there are no problems, otherwise returns a string explaining
-# what was too small.
 def check_thinpool():
+    '''
+    Returns "" if there are no problems, otherwise returns a string explaining
+    what was too small.
+    '''
     stats = get_thinpool_data()
     err = ""
     if stats['data_free'] < stats['data_min_free']:
         err += "\nThe thinpool storage free (%s) is under the minimum threshold (%s)" % \
-            (humansize(stats['data_free']), humansize(stats['data_min_free']))
+            (sizefmt.humansize(stats['data_free']), sizefmt.humansize(stats['data_min_free']))
     if stats['meta_free'] < stats['meta_min_free']:
         err += "\nThe thinpool metadata free (%s) is under the minimum threshold (%s)" % \
-            (humansize(stats['meta_free']), humansize(stats['meta_min_free']))
+            (sizefmt.humansize(stats['meta_free']), sizefmt.humansize(stats['meta_min_free']))
     return err
 
 

--- a/scripts/check-serviced-thinpool.py
+++ b/scripts/check-serviced-thinpool.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# Checks the serviced thinpool data and metadata to see if an upgrade would put the
+# system into Emergency Shutdown mode.
+#
+# Some helper scripts that are broken out in the upgrade are included here
+# to keep inspector from trying to run them as inspector scripts.
+#
+##############################################################################
+
+# zenoss-inspector-info
+# zenoss-inspector-tags verify
+# zenoss-inspector-deps serviced-config.sh
+
+import re
+import subprocess
+import sys
+
+##############################################################################
+# size format helper functions
+
+KB  = 1000
+MB  = 1000 * KB
+GB  = 1000 * MB
+TB  = 1000 * GB
+PB  = 1000 * TB
+
+KiB = 1024
+MiB = 1024 * KiB
+GiB = 1024 * MiB
+TiB = 1024 * GiB
+PiB = 1024 * TiB
+
+SIZES = {
+    'b': 1, 'kb': KiB, 'mb': MiB, 'gb': GiB, 'tb': TiB, 'pb': PiB,
+    'B': 1, 'Kb': KB, 'Mb': MB, 'Gb': GB, 'Tb': TB, 'Pb': PB,
+}
+decimapAbbrs = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+binaryAbbrs = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+sizeRegex = re.compile("^([-]?)(\d+(.\d+)?) ?([KkMmGgTtPp])?(i)?([Bb])?$")
+
+def parse_size(size):
+    """
+    Parses the human-readable size string into the amount it represents
+    as a float value. Upper case units are base 1000, lowercase base 1024.
+    If the unit has "i" in the middle it uses base 1024.
+
+    >>> parse_size("10K")
+    10000.0
+    >>> parse_size("-10K")
+    -10000.0
+    >>> parse_size("10 KB")
+    10000.0
+    >>> parse_size("10 G")
+    10000000000.0
+    >>> parse_size("10GB")
+    10000000000.0
+    >>> parse_size("10k")
+    10240.0
+    >>> parse_size("-10k")
+    -10240.0
+    >>> parse_size("10 kb")
+    10240.0
+    >>> parse_size("10gb")
+    10737418240.0
+    >>> parse_size("10g")
+    10737418240.0
+    >>> parse_size("10GiB")
+    10737418240.0
+    """
+    match = sizeRegex.match(size)
+    if not match:
+        return None
+    neg = -1 if match.group(1) else 1
+    m1 = float(match.group(2))
+    m2 = match.group(4) if match.group(4) else ''
+    if match.group(5): m2 = m2.lower()
+    m3 = match.group(6).lower() if match.group(6) else 'b'
+    return neg * m1 * SIZES[(m2 + m3)]
+
+
+def customsize(size, base, map):
+    neg = 1 if size >= 0 else -1
+    size = size * neg
+    i = 0
+    while size >= base and i < len(map)-1:
+        size = size / base
+        i = i + 1
+    size = str(round(size, 3) * neg).strip('0').strip('.') or "0"
+    return '%s %s' % (size, map[i])
+
+
+def humansize(size):
+    """
+    Converts the size string given into a human readable format
+    using 1000 as the base.
+
+    >>> humansize(0)
+    '0 B'
+    >>> humansize(-0)
+    '0 B'
+    >>> humansize(1234)
+    '1.234 KB'
+    >>> humansize(123456)
+    '123.456 KB'
+    >>> humansize(1234567890)
+    '1.235 GB'
+    >>> humansize(-1234567890)
+    '-1.235 GB'
+    """
+    if not isinstance(size, (int, float)):
+        raise ValueError('humansize() only takes int or float arguments')
+    return customsize(size, 1000.0, decimapAbbrs)
+
+
+def bytesize(size):
+    """
+    Converts the size string given into a human readable format
+    using 1024 as the base.
+
+    >>> bytesize(0)
+    '0 B'
+    >>> bytesize(-0)
+    '0 B'
+    >>> bytesize(1234)
+    '1.205 KiB'
+    >>> bytesize(123456)
+    '120.563 KiB'
+    >>> bytesize(1234567890)
+    '1.15 GiB'
+    >>> bytesize(-1234567890)
+    '-1.15 GiB'
+    >>> bytesize(1024*1024*1024)
+    '1 GiB'
+    """
+    if not isinstance(size, (int, float)):
+        raise ValueError('bytesize() only takes int or float arguments')
+    return customsize(size, 1024.0, binaryAbbrs)
+
+
+##############################################################################
+# Gather serviced and thinpool data from the that we want. 
+
+# Returns the min data and metadata storage sizes.
+def get_serviced_settings(config):
+    data = {}
+    s_storage_min_free = config.get("SERVICED_STORAGE_MIN_FREE", "3G")
+    storage_min_free = parse_size(s_storage_min_free) or (3 * GB) # Default setting if we can't parse.
+    data['SERVICED_STORAGE_MIN_FREE'] = s_storage_min_free
+    data['data_min_free'] = storage_min_free
+    data['meta_min_free'] = int(storage_min_free * 0.02)
+    return data
+
+
+# Returns a mapping representing data for the serviced thinpool.
+def get_tpool_stats(config):
+    data = {}
+    thinpooldev = config.get("SERVICED_DM_THINPOOLDEV", "serviced")
+    cmd = "lvs -o lv_size,data_percent,lv_metadata_size,metadata_percent %s 2>/dev/null | grep -vi lsize" % thinpooldev
+    stats = subprocess.check_output(cmd, shell=True).strip()
+    if not stats:
+        return data
+    stats = filter(None, stats.split(' '))
+    data['thinpooldev'] = thinpooldev
+    data['data_size'] = parse_size(stats[0])
+    data['data_percent'] = parse_size(stats[1])
+    data['data_free'] = data['data_size'] * data['data_percent']
+    data['meta_size'] = parse_size(stats[2])
+    data['meta_percent'] = parse_size(stats[3])
+    data['meta_free'] = data['meta_size'] * data['meta_percent']
+    return data
+
+
+# Parse the serviced-config output into a dict for later use.
+def parse_serviced_config():
+    with open('serviced-config.sh.stdout', 'r') as f:
+        lines = f.readlines()
+
+    data = {}
+    for line in lines:
+        line = line.strip()
+        if line.startswith('#'):
+            continue
+
+        split = line.split("=")
+        data[split[0].strip()] = split[1].strip()
+    return data
+
+
+# Returns a map of data for the serviced thin pool.
+def get_thinpool_data():
+    config = parse_serviced_config()
+    data = get_serviced_settings(config)
+    data.update(get_tpool_stats(config))
+    return data
+
+
+##############################################################################
+# After we gather the data, check that we have enough required space to keep
+# us out of emergency shutdown mode on upgrade.
+
+
+# Returns "" if there are no problems, otherwise returns a string explaining
+# what was too small.
+def check_thinpool():
+    stats = get_thinpool_data()
+    err = ""
+    if stats['data_free'] < stats['data_min_free']:
+        err += "\nThe thinpool storage free (%s) is under the minimum threshold (%s)" % \
+            (humansize(stats['data_free']), humansize(stats['data_min_free']))
+    if stats['meta_free'] < stats['meta_min_free']:
+        err += "\nThe thinpool metadata free (%s) is under the minimum threshold (%s)" % \
+            (humansize(stats['meta_free']), humansize(stats['meta_min_free']))
+    return err
+
+
+if __name__ == "__main__":
+    err = check_thinpool()
+    if err:
+        print err

--- a/scripts/lib/parse_config.py
+++ b/scripts/lib/parse_config.py
@@ -1,0 +1,30 @@
+#!/bin/python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+#
+# Parses the contents of the serviced-config.sh script into a dictionary.
+#
+##############################################################################
+
+def parse_serviced_config():
+    '''
+    Parse the serviced-config output into a dict for later use.
+    '''
+    with open('serviced-config.sh.stdout', 'r') as f:
+        lines = f.readlines()
+
+    data = {}
+    for line in lines:
+        line = line.strip()
+        if line.startswith('#'):
+            continue
+
+        split = line.split("=")
+        data[split[0].strip()] = split[1].strip()
+    return data

--- a/scripts/lib/sizefmt.py
+++ b/scripts/lib/sizefmt.py
@@ -1,0 +1,155 @@
+#!/bin/python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+#
+# Converts human readable numbers to and from numbers.
+#
+##############################################################################
+
+import re
+import sys
+
+KB  = 1000
+MB  = 1000 * KB
+GB  = 1000 * MB
+TB  = 1000 * GB
+PB  = 1000 * TB
+
+KiB = 1024
+MiB = 1024 * KiB
+GiB = 1024 * MiB
+TiB = 1024 * GiB
+PiB = 1024 * TiB
+
+SIZES = {
+    'b': 1, 'kb': KiB, 'mb': MiB, 'gb': GiB, 'tb': TiB, 'pb': PiB,
+    'B': 1, 'Kb': KB, 'Mb': MB, 'Gb': GB, 'Tb': TB, 'Pb': PB,
+}
+decimapAbbrs = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+binaryAbbrs = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+sizeRegex = re.compile("^([-]?)(\d+(.\d+)?) ?([KkMmGgTtPp])?(i)?([Bb])?$")
+
+def parse_size(size):
+    """
+    Parses the human-readable size string into the amount it represents
+    as a float value. Upper case units are base 1000, lowercase base 1024.
+    If the unit has "i" in the middle it uses base 1024.
+
+    >>> parse_size("10K")
+    10000.0
+    >>> parse_size("-10K")
+    -10000.0
+    >>> parse_size("10 KB")
+    10000.0
+    >>> parse_size("10 G")
+    10000000000.0
+    >>> parse_size("10GB")
+    10000000000.0
+    >>> parse_size("10k")
+    10240.0
+    >>> parse_size("-10k")
+    -10240.0
+    >>> parse_size("10 kb")
+    10240.0
+    >>> parse_size("10gb")
+    10737418240.0
+    >>> parse_size("10g")
+    10737418240.0
+    >>> parse_size("10GiB")
+    10737418240.0
+    """
+    match = sizeRegex.match(size)
+    if not match:
+        return None
+    neg = -1 if match.group(1) else 1
+    m1 = float(match.group(2))
+    m2 = match.group(4) if match.group(4) else ''
+    if match.group(5): m2 = m2.lower()
+    m3 = match.group(6).lower() if match.group(6) else 'b'
+    return neg * m1 * SIZES[(m2 + m3)]
+
+
+def customsize(size, base, map):
+    neg = 1 if size >= 0 else -1
+    size = size * neg
+    i = 0
+    while size >= base and i < len(map)-1:
+        size = size / base
+        i = i + 1
+    size = str(round(size, 3) * neg).strip('0').strip('.') or "0"
+    return '%s %s' % (size, map[i])
+
+
+def humansize(size):
+    """
+    Converts the size string given into a human readable format
+    using 1000 as the base.
+
+    >>> humansize(0)
+    '0 B'
+    >>> humansize(-0)
+    '0 B'
+    >>> humansize(1234)
+    '1.234 KB'
+    >>> humansize(123456)
+    '123.456 KB'
+    >>> humansize(1234567890)
+    '1.235 GB'
+    >>> humansize(-1234567890)
+    '-1.235 GB'
+    """
+    if not isinstance(size, (int, float)):
+        raise ValueError('humansize() only takes int or float arguments')
+    return customsize(size, 1000.0, decimapAbbrs)
+
+
+def bytesize(size):
+    """
+    Converts the size string given into a human readable format
+    using 1024 as the base.
+
+    >>> bytesize(0)
+    '0 B'
+    >>> bytesize(-0)
+    '0 B'
+    >>> bytesize(1234)
+    '1.205 KiB'
+    >>> bytesize(123456)
+    '120.563 KiB'
+    >>> bytesize(1234567890)
+    '1.15 GiB'
+    >>> bytesize(-1234567890)
+    '-1.15 GiB'
+    >>> bytesize(1024*1024*1024)
+    '1 GiB'
+    """
+    if not isinstance(size, (int, float)):
+        raise ValueError('bytesize() only takes int or float arguments')
+    return customsize(size, 1024.0, binaryAbbrs)
+
+
+def __test():
+    """
+    Make sure a round-trip conversions works.
+
+    >>> parse_size(humansize(0))
+    0.0
+    >>> parse_size(humansize(10000))
+    10000.0
+    >>> parse_size(bytesize(1024*1024*1024))
+    1073741824.0
+    """
+    pass
+
+
+if __name__ == '__main__':
+    import doctest
+    # If run, make sure test cases pass.
+    doctest.testmod()
+

--- a/scripts/lib/sizefmt.py
+++ b/scripts/lib/sizefmt.py
@@ -33,6 +33,16 @@ SIZES = {
 }
 decimapAbbrs = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 binaryAbbrs = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
+
+# Not the most intuitive regular expression.  Groups here will be:
+# group(1): None or "-" for negative numbers
+# group(2): The numeric part of the string, ie "10.3"
+# group(3): [unused] the decimal portion for floats, ie ".3"
+# group(4): (The first letter denoting the unit "G", "k", "M", etc)
+# group(5): None or "i" if this is given in binary abbreviations. If provided
+#           then group(4) is forced lowercase (10 GiB is translatd to 10 gb)
+#           for the purpose of looking up the value in the SIZES dictionary.
+# group(6): None, "b", or "B".  Will always be "b" for SIZES lookups.
 sizeRegex = re.compile("^([-]?)(\d+(.\d+)?) ?([KkMmGgTtPp])?(i)?([Bb])?$")
 
 def parse_size(size):
@@ -76,6 +86,13 @@ def parse_size(size):
 
 
 def customsize(size, base, map):
+    """
+    Takes a number, a base (ie: 1000 for humansize or 1024 for
+    bytesize), and a map of abbreviations for the steps.  Returns
+    the number rounded to 3 decimal places matched to the abbreviation
+    it falls into.  See the comments in humansize() and bytesize()
+    for examples of the output.
+    """
     neg = 1 if size >= 0 else -1
     size = size * neg
     i = 0

--- a/scripts/lib/thinpool_stats.py
+++ b/scripts/lib/thinpool_stats.py
@@ -1,0 +1,97 @@
+#!/bin/python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+#
+# Returns stats on the serviced data and metadata volumes.  This doesn't try
+# to mount the tenant volumes to get stats on those.
+#
+##############################################################################
+
+import re
+import subprocess
+
+import sizefmt
+import parse_config
+
+
+def get_serviced_settings(config):
+    """
+    Returns the min data and metadata storage sizes.
+    """
+    data = {}
+    s_storage_min_free = config.get("SERVICED_STORAGE_MIN_FREE", "3G")
+    storage_min_free = sizefmt.parse_size(s_storage_min_free) or (3 * sizefmt.GB) # Default setting if we can't parse.
+    data['SERVICED_STORAGE_MIN_FREE'] = s_storage_min_free
+    data['data_min_free'] = storage_min_free
+    data['meta_min_free'] = int(storage_min_free * 0.02)
+    return data
+
+
+def calc_tpool_stats(stats):
+    """
+    Calculates the thinpool stats based on the lvs output provided and returns them.
+
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['data_size']
+    107374182400.0
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['data_percent']
+    0.01
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['meta_size']
+    1073741824.0
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['meta_percent']
+    0.02
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['meta_free']
+    1052266987.52
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['meta_used']
+    21474836.48
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['data_free']
+    106300440576.0
+    >>> calc_tpool_stats('  100.00g 1.00   1.00g 2.00')['data_used']
+    1073741824.0
+    """
+    data = {}
+    stats = filter(None, stats.split(' '))
+    data['data_size'] = sizefmt.parse_size(stats[0])
+    data['data_percent'] = sizefmt.parse_size(stats[1]) / 100
+    data['data_used'] = data['data_size'] * data['data_percent']
+    data['data_free'] = data['data_size'] * (1-data['data_percent'])
+    data['meta_size'] = sizefmt.parse_size(stats[2])
+    data['meta_percent'] = sizefmt.parse_size(stats[3]) / 100
+    data['meta_used'] = data['meta_size'] * data['meta_percent']
+    data['meta_free'] = data['meta_size'] * (1-data['meta_percent'])
+    return data
+
+
+def get_tpool_stats(config):
+    """
+    Returns a mapping representing data for the serviced thinpool.
+    """
+    thinpooldev = config.get("SERVICED_DM_THINPOOLDEV", "serviced")
+    cmd = "lvs -o lv_size,data_percent,lv_metadata_size,metadata_percent %s 2>/dev/null | grep -vi lsize" % thinpooldev
+    stats = subprocess.check_output(cmd, shell=True).strip()
+    if not stats:
+        return {}
+    data = calc_tpool_stats(stats)
+    data['thinpooldev'] = thinpooldev
+    return data
+
+
+def get_thinpool_data():
+    """
+    Returns a map of data for the serviced thin pool.
+    """
+    config = parse_config.parse_serviced_config()
+    data = get_serviced_settings(config)
+    data.update(get_tpool_stats(config))
+    return data
+
+
+if __name__ == '__main__':
+     # If run, make sure test cases pass.
+     import doctest
+     doctest.testmod()

--- a/scripts/thinpool_data.py
+++ b/scripts/thinpool_data.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+#
+# Gathers the thinpool data used in other scripts.
+#
+##############################################################################
+
+# zenoss-inspector-tags verify
+# zenoss-inspector-deps serviced-config.sh
+
+import lib.thinpool_stats as thinpool_stats
+from pprint import pprint
+
+if __name__ == "__main__":
+    data = thinpool_stats.get_thinpool_data()
+    pprint(data)


### PR DESCRIPTION
https://jira.zenoss.com/browse/INSP-85

Check the thinpool storage and metadata to make sure they're within the emergency shutdown thresholds.  Reports the thinpool stats into an output file for later, and uses that to report on the thresholds. 