### PR TITLE
Add system, docker, and serviced limit information

### DIFF
--- a/scripts/docker-limits.sh
+++ b/scripts/docker-limits.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# zenoss-inspector-tags config docker
+
+cat /proc/$(pidof dockerd || pidof docker)/limits

--- a/scripts/serviced-limits.sh
+++ b/scripts/serviced-limits.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# zenoss-inspector-tags config serviced
+
+# We have to ignore all of the other 'serviced <x>' commands being run by inspector
+pid=$(ps waux | grep 'serviced [s]erver' | awk '{ print $2 }')
+
+cat /proc/${pid}/limits

--- a/scripts/system-limits.sh
+++ b/scripts/system-limits.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# zenoss-inspector-tags config
+
+ulimit -a


### PR DESCRIPTION
https://jira.zenoss.com/browse/INSP-58
Adds docker-limits.stdout, serviced-limits.stdout, and system-limits.stdout to the inspector data.