### PR TITLE
Replace 'worker' with 'delegate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ Compressing results: inspected-2015-10-09T12-48-47.054684.tar.gz
 Cleaning up...
 ```
 
+### Running only verification checks
+Inspector has two main functions - it collects a wide variety of information that might be useful when
+doing root-cause analysis on a problem, and it verifies a number of install and operational requirements.
+
+To run just the verification steps, use the following:
+```
+$ ./inspect -w verify
+```
+
+### Inspecting CC delegate nodes
+Inspector assumes the target is a CC master node.  It can be run on a CC delegate node, but will produce
+a number of complaints that are not relevant on a CC delegate.
+For instance, the storage configuration on a CC delegate node is much simpler.
+
+To run only the checks that make sense for a CC delegate node use:
+```
+$ ./inspect-delegate.sh
+```
+
 ### Inspecting with options
 Inspections can be performed with a handful of options. To use inspector in this fashion, just
 download the master branch, unzip it, and run inspect:

--- a/inspect-delegate.sh
+++ b/inspect-delegate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./inspect --whitelist docker network os serviced-delegate $*

--- a/inspect-serviced-worker.sh
+++ b/inspect-serviced-worker.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./inspect --whitelist docker network os serviced-worker $*

--- a/scripts/check-nfs-server-service.py
+++ b/scripts/check-nfs-server-service.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-deps nfs-server-service.sh serviced-major-minor-version.sh
-# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-tags config serviced serviced-delegate verify
 # zenoss-inspector-info
 
 

--- a/scripts/etc-default-serviced-filtered.sh
+++ b/scripts/etc-default-serviced-filtered.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker ha verify
+# zenoss-inspector-tags serviced serviced-delegate ha verify
 
 #
 # Filter the CC configuration to exclude comments and blank links.

--- a/scripts/etc-default-serviced.sh
+++ b/scripts/etc-default-serviced.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker ha verify
+# zenoss-inspector-tags serviced serviced-delegate ha verify
 
 #
 # Capture the complete contents of the configuration so we can see

--- a/scripts/get-ha-versions.sh
+++ b/scripts/get-ha-versions.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-# zenoss-inspector-tags rpm ha verify
+#
+# Even though there is nothing HA-specific about CC delegates, we need to include
+# the serviced-delegate tag because some generic collection scripts rely on
+# this script to tell them whether they need additional/different checks for
+# HA. For example, see systemctl-status.sh.
+#
+
+# zenoss-inspector-tags rpm ha serviced-delegate verify
 # zenoss-inspector-deps get-rpms.sh
 
 HAS_DRBD=false

--- a/scripts/get-rpms.sh
+++ b/scripts/get-rpms.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# zenoss-inspector-tags rpm docker ha verify os
+# zenoss-inspector-tags rpm docker ha os serviced-delegate verify
 rpm -qa

--- a/scripts/journalctl-serviced.sh
+++ b/scripts/journalctl-serviced.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker
+# zenoss-inspector-tags serviced serviced-delegate
 
 journalctl -u serviced
 

--- a/scripts/localhost-loopback.py
+++ b/scripts/localhost-loopback.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # zenoss-inspector-info
-# zenoss-inspector-tags network verify
+# zenoss-inspector-tags network serviced-delegate verify
 # zenoss-inspector-deps etchosts.sh
 
 def main():
@@ -12,8 +12,7 @@ def main():
         if "127.0.0.1" in split and "localhost" in split:
             return
     print ("You don't appear to have a mapping for localhost to 127.0.0.1 in "
-           "your /etc/hosts file. This will cause issues until "
-           "https://jira.zenoss.com/browse/CC-1423 is resolved.")
+           "your /etc/hosts file.")
 
 if __name__ == "__main__":
     main()

--- a/scripts/lvs.sh
+++ b/scripts/lvs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# zenoss-inspector-tags verify
+# zenoss-inspector-tags serviced-delegate verify
 #
 
 lvs --all -o+lv_kernel_major,lv_kernel_minor,seg_monitor

--- a/scripts/nfs-server-service.sh
+++ b/scripts/nfs-server-service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-deps serviced-major-minor-version.sh
-# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-tags config serviced serviced-delegate verify
 
 # RM installation doc 1.2 recommends to use nfs-server drop-in conf files
 

--- a/scripts/pvs.sh
+++ b/scripts/pvs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# zenoss-inspector-tags verify
+# zenoss-inspector-tags serviced-delegate verify
 #
 
 pvs --all

--- a/scripts/service-status.py
+++ b/scripts/service-status.py
@@ -2,7 +2,7 @@
 
 # zenoss-inspector-info
 # zenoss-inspector-deps systemctl-status.sh get-ha-versions.sh
-# zenoss-inspector-tags docker serviced serviced-worker verify ha
+# zenoss-inspector-tags docker serviced serviced-delegate verify ha
 
 def print_time_sync_warning():
     print "Please ensure you have some form of time synchronization in place on all hosts"

--- a/scripts/serviced-config-delegate.sh
+++ b/scripts/serviced-config-delegate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # zenoss-inspector-info
-# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-tags config serviced serviced-delegate verify
 # zenoss-inspector-deps serviced-config.sh serviced-major-minor-version.sh
 
 # Verify that if this is a master node, that it is also an agent

--- a/scripts/serviced-config.sh
+++ b/scripts/serviced-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker verify
+# zenoss-inspector-tags serviced serviced-delegate verify
 
 serviced config

--- a/scripts/serviced-major-minor-version.sh
+++ b/scripts/serviced-major-minor-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-tags config serviced serviced-delegate verify
 
 serviced version | grep -w 'Version:' | awk '{print $2}' | cut -d\. -f1-2
 

--- a/scripts/serviced-running.sh
+++ b/scripts/serviced-running.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags verify serviced-worker
+# zenoss-inspector-tags verify serviced-delegate
 # zenoss-inspector-deps systemctl-status.sh
 
 SERVICED_RUNNING=false

--- a/scripts/serviced-storage.sh
+++ b/scripts/serviced-storage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# zenoss-inspector-tags serviced serviced-worker verify
+# zenoss-inspector-tags serviced verify
 
 serviced-storage status -o=dm.thinpooldev=serviced-serviced--pool /opt/serviced/var/volumes

--- a/scripts/serviced-version.sh
+++ b/scripts/serviced-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags config serviced serviced-worker verify
+# zenoss-inspector-tags config serviced serviced-delegate verify
 
 serviced version
 

--- a/scripts/storage-config.sh
+++ b/scripts/storage-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# zenoss-inspector-tags verify
+# zenoss-inspector-tags serviced-delegate verify
 #
 # This script captures information about the OS storage configuration on the
 # host machine. See also pvs.sh, vgs.sh and lvs.sh

--- a/scripts/systemctl-status.sh
+++ b/scripts/systemctl-status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# zenoss-inspector-tags docker serviced serviced-worker verify ha
+# zenoss-inspector-tags docker serviced serviced-delegate verify ha
 # zenoss-inspector-deps get-ha-versions.sh
 
 systemctl show --property=Names,Description,LoadState,ActiveState,UnitFileState dnsmasq

--- a/scripts/vgs.sh
+++ b/scripts/vgs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# zenoss-inspector-tags verify
+# zenoss-inspector-tags serviced-delegate verify
 #
 
 vgs --all


### PR DESCRIPTION
Fixes INSP-47 and INSP-76

- replace the term 'worker' with 'delegate'
- add the tag `serviced-delegate` to some additional verification scripts.