### PR TITLE
Error out of docker-stats if not running

### DIFF
--- a/scripts/docker-stats.sh
+++ b/scripts/docker-stats.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
 # zenoss-inspector-tags docker
+# zenoss-inspector-deps ps-aux.sh
+
+egrep "(docker -d|docker daemon|dockerd)" ps-aux.sh.stdout &>/dev/null
+
+if [ $? -ne 0 ]; then
+    (>&2 echo "Docker doesn't appear to be running.")
+    exit 1
+fi
 
 docker ps -q | xargs docker stats --no-stream
 


### PR DESCRIPTION
If docker isn't running, docker-stats times out infinitely.  Instead, error out if it isn't running.