### PR TITLE
Feature/insp 95 - DO NOT MERGE YET

### DIFF
--- a/scripts/opentsdb-uid.py
+++ b/scripts/opentsdb-uid.py
@@ -8,87 +8,61 @@ from collections import defaultdict
 import subprocess as sp
 import sys
 
-# def get_cc_running():
-#     cc_running = ""
-#     with open('serviced-running.sh.stdout', 'r') as f:
-#         cc_running = f.read().strip()
-#     return cc_running
-#
-# def get_services_deployed():
-#     services_deployed = ""
-#     with open('serviced-service-deployed.sh.stdout', 'r') as f:
-#         services_deployed = f.read().strip()
-#     return services_deployed
-
 
 def run(cmd):
     p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         if "service not found" in stderr:
-            print "The service named 'writer' was not found; skipping check " \
-                  "for opentsdb TTL. "
+            print "The service named 'reader' was not found; skipping check " \
+                  "for opentsdb UID. "
             sys.exit(0)
         else:
             raise sp.CalledProcessError(p.returncode, ' '.join(cmd))
     return stdout, stderr
 
 
-def serviced_is_running():
+def verify_serviced_is_running():
     with open('serviced-running.sh.stdout', 'r') as f:
         cc_running = f.read().strip()
     if cc_running == "SERVICED_RUNNING=false":
-        return False
-    return True
-
-
-
-def services_are_deployed():
-    with open('serviced-service-deployed.sh.stdout', 'r') as f:
-        services_deployed = f.read().strip()
-    if services_deployed == "SERVICES_DEPLOYED=false":
-        print "No Zenoss services deployed; skipping check for opentsdb TTL."
-        sys.exit(0)
-    return True
-
-
-def main():
-    if not serviced_is_running():
         print "Serviced is not running; skipping check for opentsdb UID."
         sys.exit(0)
 
-    if not services_are_deployed():
+
+def verify_services_are_deployed():
+    with open('serviced-service-deployed.sh.stdout', 'r') as f:
+        services_deployed = f.read().strip()
+    if services_deployed == "SERVICES_DEPLOYED=false":
         print "No Zenoss services deployed; skipping check for opentsdb UID."
         sys.exit(0)
 
-    print "Opentsdb UID check can continue - serviced is running and " \
-          "services are deployed. "
 
-    cmd = ["serviced", "service", "attach", "reader",
+def main():
+    verify_serviced_is_running()
+    verify_services_are_deployed()
+
+    cmd = ["serviced", "service", "shell", "reader",
            "/opt/opentsdb/build/tsdb", "uid", "--config",
            "/opt/zenoss/etc/opentsdb/opentsdb.conf", "grep", "."]
+
     stdout, stderr = run(cmd)
     d = defaultdict(list)
     for line in stdout.split("\n"):
         try:
             type, name, id = line.split(" ", 2)
-            # import pdb; pdb.set_trace()
             if name == '\x00:':
-                # print "skipping: [{}, {}, {}]".format(type, name, id)
                 continue
             d["{} {}".format(type, id.strip())].append(name.rstrip(':'))
-            # print "type: {}\tname: {}\tid: {}".format(type, name, id)
         except ValueError:
-            print "ValueError splitting line: {}".format(line)
-        # print "line: {}\n".format(line)
+            continue
 
-    multiples = [v for _,v in d.items() if len(v) > 1]
-    singles = [v for _,v in d.items() if len(v) == 1]
-    print "{} multiple-mapped ids and {} single-mapped ids were found".format(len(multiples), len(singles))
+    multiples = [v for _, v in d.items() if len(v) > 1]
 
+    if len(multiples) > 0:
+        print "OpenTSDB UIDs are corrupt. There multiple mappings for {} ids."\
+            .format(len(multiples))
 
-    # print "STDOUT:\n=======\n{}\n".format(stdout)
-    print "\nSTDERR:\n=======\n{}\n".format(stderr)
 
 if __name__ == "__main__":
     main()

--- a/scripts/opentsdb-uid.py
+++ b/scripts/opentsdb-uid.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# zenoss-inspector-info
+# zenoss-inspector-tags opentsdb INSP-95
+# zenoss-inspector-deps serviced-running.sh serviced-service-deployed.sh
+
+from collections import defaultdict
+import subprocess as sp
+import sys
+
+# def get_cc_running():
+#     cc_running = ""
+#     with open('serviced-running.sh.stdout', 'r') as f:
+#         cc_running = f.read().strip()
+#     return cc_running
+#
+# def get_services_deployed():
+#     services_deployed = ""
+#     with open('serviced-service-deployed.sh.stdout', 'r') as f:
+#         services_deployed = f.read().strip()
+#     return services_deployed
+
+
+def run(cmd):
+    p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        if "service not found" in stderr:
+            print "The service named 'writer' was not found; skipping check " \
+                  "for opentsdb TTL. "
+            sys.exit(0)
+        else:
+            raise sp.CalledProcessError(p.returncode, ' '.join(cmd))
+    return stdout, stderr
+
+
+def serviced_is_running():
+    with open('serviced-running.sh.stdout', 'r') as f:
+        cc_running = f.read().strip()
+    if cc_running == "SERVICED_RUNNING=false":
+        return False
+    return True
+
+
+
+def services_are_deployed():
+    with open('serviced-service-deployed.sh.stdout', 'r') as f:
+        services_deployed = f.read().strip()
+    if services_deployed == "SERVICES_DEPLOYED=false":
+        print "No Zenoss services deployed; skipping check for opentsdb TTL."
+        sys.exit(0)
+    return True
+
+
+def main():
+    if not serviced_is_running():
+        print "Serviced is not running; skipping check for opentsdb UID."
+        sys.exit(0)
+
+    if not services_are_deployed():
+        print "No Zenoss services deployed; skipping check for opentsdb UID."
+        sys.exit(0)
+
+    print "Opentsdb UID check can continue - serviced is running and " \
+          "services are deployed. "
+
+    cmd = ["serviced", "service", "attach", "reader",
+           "/opt/opentsdb/build/tsdb", "uid", "--config",
+           "/opt/zenoss/etc/opentsdb/opentsdb.conf", "grep", "."]
+    stdout, stderr = run(cmd)
+    d = defaultdict(list)
+    for line in stdout.split("\n"):
+        try:
+            type, name, id = line.split(" ", 2)
+            # import pdb; pdb.set_trace()
+            if name == '\x00:':
+                # print "skipping: [{}, {}, {}]".format(type, name, id)
+                continue
+            d["{} {}".format(type, id.strip())].append(name.rstrip(':'))
+            # print "type: {}\tname: {}\tid: {}".format(type, name, id)
+        except ValueError:
+            print "ValueError splitting line: {}".format(line)
+        # print "line: {}\n".format(line)
+
+    multiples = [v for _,v in d.items() if len(v) > 1]
+    singles = [v for _,v in d.items() if len(v) == 1]
+    print "{} multiple-mapped ids and {} single-mapped ids were found".format(len(multiples), len(singles))
+
+
+    # print "STDOUT:\n=======\n{}\n".format(stdout)
+    print "\nSTDERR:\n=======\n{}\n".format(stderr)
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/scripts/opentsdb-uid.py
+++ b/scripts/opentsdb-uid.py
@@ -67,7 +67,7 @@ def main():
     multiples = [v for _, v in d.items() if len(v) > 1]
     mc = len(multiples)
     if mc > 0:
-        print "OpenTSDB UIDs are corrupt. There are {} UIDs with multiple " \
+        print "Some OpenTSDB UIDs are corrupt. There are {} UIDs with multiple " \
               "mappings. Contact Zenoss support for assistance.".format(mc)
 
 

--- a/scripts/opentsdb-uid.py
+++ b/scripts/opentsdb-uid.py
@@ -4,18 +4,23 @@
 # zenoss-inspector-tags opentsdb INSP-95
 # zenoss-inspector-deps serviced-running.sh serviced-service-deployed.sh
 
-from collections import defaultdict
 import subprocess as sp
 import sys
+from collections import defaultdict
 
 
-def run(cmd):
+def run_tsdb_cmd():
+    """Run OpenTSDB command to get UID information."""
+    cmd = ["serviced", "service", "shell", "reader",
+           "/opt/opentsdb/build/tsdb", "uid", "--config",
+           "/opt/zenoss/etc/opentsdb/opentsdb.conf", "grep", "."]
+
     p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         if "service not found" in stderr:
             print "The service named 'reader' was not found; skipping check " \
-                  "for opentsdb UID. "
+                  "for OpenTSDB UID corruption."
             sys.exit(0)
         else:
             raise sp.CalledProcessError(p.returncode, ' '.join(cmd))
@@ -23,49 +28,48 @@ def run(cmd):
 
 
 def verify_serviced_is_running():
+    """Make sure serviced is running. If not, print error and exit."""
     with open('serviced-running.sh.stdout', 'r') as f:
         cc_running = f.read().strip()
     if cc_running == "SERVICED_RUNNING=false":
-        print "Serviced is not running; skipping check for opentsdb UID."
+        print "Serviced is not running; skipping check for OpenTSDB UID " \
+              "corruption. "
         sys.exit(0)
 
 
 def verify_services_are_deployed():
+    """Make sure services are deployed. If not, print error and exit."""
     with open('serviced-service-deployed.sh.stdout', 'r') as f:
         services_deployed = f.read().strip()
     if services_deployed == "SERVICES_DEPLOYED=false":
-        print "No Zenoss services deployed; skipping check for opentsdb UID."
+        print "No Zenoss services deployed; skipping check for OpenTSDB UID " \
+              "corruption. "
         sys.exit(0)
 
 
 def main():
+    """Check for double-mapped OpenTSDB UIDs. Warn user if corrupted."""
     verify_serviced_is_running()
     verify_services_are_deployed()
 
-    cmd = ["serviced", "service", "shell", "reader",
-           "/opt/opentsdb/build/tsdb", "uid", "--config",
-           "/opt/zenoss/etc/opentsdb/opentsdb.conf", "grep", "."]
+    stdout, _ = run_tsdb_cmd()
 
-    stdout, stderr = run(cmd)
     d = defaultdict(list)
     for line in stdout.split("\n"):
         try:
-            type, name, id = line.split(" ", 2)
+            kind, name, uid = line.split(" ", 2)
             if name == '\x00:':
                 continue
-            d["{} {}".format(type, id.strip())].append(name.rstrip(':'))
+            d["{} {}".format(kind, uid.strip())].append(name.rstrip(':'))
         except ValueError:
             continue
 
     multiples = [v for _, v in d.items() if len(v) > 1]
-
-    if len(multiples) > 0:
-        print "OpenTSDB UIDs are corrupt. There multiple mappings for {} ids."\
-            .format(len(multiples))
+    mc = len(multiples)
+    if mc > 0:
+        print "OpenTSDB UIDs are corrupt. There are {} UIDs with multiple " \
+              "mappings. Contact Zenoss support for assistance.".format(mc)
 
 
 if __name__ == "__main__":
     main()
-
-
-


### PR DESCRIPTION
Do not merge until we work out messaging for this with support/services.

Add script to check OpenTSDB for UIDs that are mapped to more than one string. If this corruption occurs, it's a pretty bad situation and may be unrecoverable. We're working on proper messaging, and making sure support/services/engineering are set up to handle this if it occurs.

As the code stands right now, if the error condition is found, the following message is displayed: 

`OpenTSDB UIDs are corrupt. There are <#> UIDs with multiple mappings. Contact Zenoss support for assistance.`

We're working with support/services to finalize the messaging before we merge this.